### PR TITLE
Keep references to input arrays in guru plan struct

### DIFF
--- a/src/guru.jl
+++ b/src/guru.jl
@@ -171,7 +171,7 @@ function finufft_setpts!(plan::finufft_plan{T},
 
     # Store references to input arrays in plan struct.
     # This is important, since Julia garbage collection
-    # will not now about the C library keeping references
+    # will not know about the C library keeping references
     # to the input arrays.
     plan._xj = xj
     plan._yj = yj


### PR DESCRIPTION
This should hopefully avoid segfault due to users not knowing exactly how the memory management works under the hood.

Fixes #39