### PR TITLE
feat: test thread-safety

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
 #          - 'nightly'
         os:
@@ -17,13 +17,10 @@ jobs:
           - windows-latest
         arch:
           - x64
-          - arm64
-        exclude:
+        include:
           - os: macOS-latest
             arch: arm64
-            version: '1.6'
-          - os: windows-latest
-            arch: arm64
+            version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,10 +17,10 @@ jobs:
           - windows-latest
         arch:
           - x64
-          - arm64
-        exclude:
-          - os: windows-latest
+        include:
+          - os: macOS-latest
             arch: arm64
+            version: 1.10
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+          - arm64
+        exclude:
+          - os: windows-latest
+            arch: arm64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: macOS-latest
             arch: arm64
-            version: 1.10
+            version: '1.10'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: ${{ env.NUM_THREADS || 2 }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,10 +17,13 @@ jobs:
           - windows-latest
         arch:
           - x64
-        include:
+          - arm64
+        exclude:
           - os: macOS-latest
             arch: arm64
-            version: '1.10'
+            version: '1.6'
+          - os: windows-latest
+            arch: arm64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -24,4 +24,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [targets]
-test = ["Test", "LinearAlgebra", "Random", "CUDA", "Logging"]
+test = ["Test", "LinearAlgebra", "Random", "CUDA", "Logging", "FFTW"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ julia = "1.6"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 @testset "FINUFFT" begin
     include("test_error_handler.jl")
     include("test_nufft.jl")
+    include("test_thread_safety.jl")
 end
 @testset "cuFINUFFT" begin
     include("test_cuda.jl")

--- a/test/test_thread_safety.jl
+++ b/test/test_thread_safety.jl
@@ -14,75 +14,38 @@ function test_nufft_in_threads(tol::Real, dtype::DataType)
     T = dtype    # abbrev; we no longer infer dtype as type of tol
     # (this would be confusing since tol can be any type)
     nj = 10      # sizes for this small test: # NU pts
-    nk = 11      # targ NU pts for t3
     ms = 12      # modes x
-    mt = 13      # modes y
-    mu = 14      # modes z
 
     # nonuniform data, using the full allowed input domain [-3pi,3pi)
     x = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
-    y = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
-    z = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
     c = rand(rng, Complex{T}, nj)
-    s = rand(rng, T, nk)
-    t = rand(rng, T, nk)
-    u = rand(rng, T, nk)
-    f = rand(rng, Complex{T}, nk)
-
-    # uniform data
-    F1D = rand(rng, Complex{T}, ms)
-    F2D = rand(rng, Complex{T}, ms, mt)
-    F3D = rand(rng, Complex{T}, ms, mt, mu)
 
     modevec(m) = -floor(m / 2):floor((m - 1) / 2 + 1)
     k1 = modevec(ms)
-    k2 = modevec(mt)
-    k3 = modevec(mu)
 
     errfac = 100       # allowed multiple of tol for errors rel to direct calc
-    errdifffac = 10    # allowed multiple of tol for errors rel to 2nd NUFFT
 
-    @testset "Test FINUFF thread-safety in 1D ($T)" begin
+    @testset "Test FINUFFT thread-safety ($T)" begin
         ## 1D
-        @testset "1D Type 1" begin
+        @testset "For now only 1D Type 1" begin
 
             ref = zeros(Complex{T}, ms)     # direct calc...
             for j = 1:nj
                 for ss = 1:ms
-                    ref[ss] += c[j] * exp(1im * k1[ss] * x[j])
+                    ref[ss] += c[j] * cis(k1[ss] * x[j])
                 end
             end
 
             iters = 100
-            flag1 = falses(iters)
-            flag2 = falses(iters)
-            flag3 = falses(iters)
-
-
+            flag = falses(iters)
+            
             Threads.@threads for i = 1:iters
-                out = zeros(Complex{T}, ms)
-                # Simple, writing into array, setting some non-default opts...
-                nufft1d1!(x, c, 1, tol, out, debug=0, spread_sort=0, nthreads=1)
-                relerr_1d1 = norm(vec(out) - vec(ref), Inf) / norm(vec(ref), Inf)
-                flag1[i] = relerr_1d1 < errfac * tol
-
-                # Different caller which returns array
-                out2 = nufft1d1(x, c, 1, tol, ms, nthreads=1)
-                reldiff = norm(vec(out) - vec(out2), Inf) / norm(vec(out), Inf)
-                flag2[i] = reldiff < errdifffac * tol
-
-                # Guru interface
-                plan = finufft_makeplan(1, [ms;], 1, 1, tol, dtype=T, nthreads=1)
-                finufft_setpts!(plan, x)
-                out3 = finufft_exec(plan, c)
-                finufft_destroy!(plan)
-                relerr_guru = norm(vec(out3) - vec(ref), Inf) / norm(vec(ref), Inf)
-                flag3[i] = relerr_guru < errfac * tol
+                out = nufft1d1(x, c, 1, tol, ms, nthreads=1)
+                relerr_1d1 = norm(vec(out) .- vec(ref), Inf) / norm(vec(ref), Inf)
+                flag[i] = relerr_1d1 < errfac * tol
             end
 
-            @test all(flag1)
-            @test all(flag2)
-            @test all(flag3)
+            @test all(flag)
         end
     end
 end

--- a/test/test_thread_safety.jl
+++ b/test/test_thread_safety.jl
@@ -1,0 +1,91 @@
+# threading tester for FINUFFT.jl
+
+using FINUFFT
+
+using Test
+using LinearAlgebra
+using Random
+
+function test_nufft_in_threads(tol::Real, dtype::DataType)
+    @assert dtype <: FINUFFT.finufftReal
+
+    rng = MersenneTwister(1)
+
+    T = dtype    # abbrev; we no longer infer dtype as type of tol
+    # (this would be confusing since tol can be any type)
+    nj = 10      # sizes for this small test: # NU pts
+    nk = 11      # targ NU pts for t3
+    ms = 12      # modes x
+    mt = 13      # modes y
+    mu = 14      # modes z
+
+    # nonuniform data, using the full allowed input domain [-3pi,3pi)
+    x = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
+    y = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
+    z = Array{T}(3 * pi * (2 * rand(rng, nj) .- 1.0))
+    c = rand(rng, Complex{T}, nj)
+    s = rand(rng, T, nk)
+    t = rand(rng, T, nk)
+    u = rand(rng, T, nk)
+    f = rand(rng, Complex{T}, nk)
+
+    # uniform data
+    F1D = rand(rng, Complex{T}, ms)
+    F2D = rand(rng, Complex{T}, ms, mt)
+    F3D = rand(rng, Complex{T}, ms, mt, mu)
+
+    modevec(m) = -floor(m / 2):floor((m - 1) / 2 + 1)
+    k1 = modevec(ms)
+    k2 = modevec(mt)
+    k3 = modevec(mu)
+
+    errfac = 100       # allowed multiple of tol for errors rel to direct calc
+    errdifffac = 10    # allowed multiple of tol for errors rel to 2nd NUFFT
+
+    @testset "Test FINUFF thread-safety in 1D ($T)" begin
+        ## 1D
+        @testset "1D Type 1" begin
+
+            ref = zeros(Complex{T}, ms)     # direct calc...
+            for j = 1:nj
+                for ss = 1:ms
+                    ref[ss] += c[j] * exp(1im * k1[ss] * x[j])
+                end
+            end
+
+            iters = 100
+            flag1 = falses(iters)
+            flag2 = falses(iters)
+            flag3 = falses(iters)
+
+
+            Threads.@threads for i = 1:iters
+                out = zeros(Complex{T}, ms)
+                # Simple, writing into array, setting some non-default opts...
+                nufft1d1!(x, c, 1, tol, out, debug=0, spread_sort=0, nthreads=1)
+                relerr_1d1 = norm(vec(out) - vec(ref), Inf) / norm(vec(ref), Inf)
+                flag1[i] = relerr_1d1 < errfac * tol
+
+                # Different caller which returns array
+                out2 = nufft1d1(x, c, 1, tol, ms, nthreads=1)
+                reldiff = norm(vec(out) - vec(out2), Inf) / norm(vec(out), Inf)
+                flag2[i] = reldiff < errdifffac * tol
+
+                # Guru interface
+                plan = finufft_makeplan(1, [ms;], 1, 1, tol, dtype=T, nthreads=1)
+                finufft_setpts!(plan, x)
+                out3 = finufft_exec(plan, c)
+                finufft_destroy!(plan)
+                relerr_guru = norm(vec(out3) - vec(ref), Inf) / norm(vec(ref), Inf)
+                flag3[i] = relerr_guru < errfac * tol
+            end
+
+            @test all(flag1)
+            @test all(flag2)
+            @test all(flag3)
+        end
+    end
+end
+
+test_nufft_in_threads(1e-14, Float64)
+test_nufft_in_threads(1e-4, Float32)

--- a/test/test_thread_safety.jl
+++ b/test/test_thread_safety.jl
@@ -26,7 +26,7 @@ function test_nufft_in_threads(tol::Real, dtype::DataType)
 
     errfac = 100       # allowed multiple of tol for errors rel to direct calc
 
-    @testset "Test FINUFFT thread-safety ($T)" begin
+    @testset "Thread-safety: FINUFFT + FFTW ($T)" begin
         ## 1D
         @testset "For now only 1D Type 1" begin
 
@@ -40,7 +40,7 @@ function test_nufft_in_threads(tol::Real, dtype::DataType)
             iters = 100
             flag = falses(iters)
 
-            # Run twice - just to be safe
+            # Run twice as pre finufft_jll 2.5.0+1 segmentation faults on MacOS sometimes occured only on the second run (libfinufft was built with Clang)
             for j = 1:2
                 Threads.@threads for i = 1:iters
                     out = nufft1d1(x, c, 1, tol, ms, nthreads=1)

--- a/test/test_thread_safety.jl
+++ b/test/test_thread_safety.jl
@@ -1,5 +1,6 @@
 # threading tester for FINUFFT.jl
 
+using FFTW
 using FINUFFT
 
 using Test
@@ -38,11 +39,17 @@ function test_nufft_in_threads(tol::Real, dtype::DataType)
 
             iters = 100
             flag = falses(iters)
-            
-            Threads.@threads for i = 1:iters
-                out = nufft1d1(x, c, 1, tol, ms, nthreads=1)
-                relerr_1d1 = norm(vec(out) .- vec(ref), Inf) / norm(vec(ref), Inf)
-                flag[i] = relerr_1d1 < errfac * tol
+
+            # Run twice - just to be safe
+            for j = 1:2
+                Threads.@threads for i = 1:iters
+                    out = nufft1d1(x, c, 1, tol, ms, nthreads=1)
+                    relerr_1d1 = norm(vec(out) .- vec(ref), Inf) / norm(vec(ref), Inf)
+                    flag[i] = relerr_1d1 < errfac * tol
+
+                    # make sure, we can run safely along fft calls
+                    fft(c)
+                end
             end
 
             @test all(flag)


### PR DESCRIPTION
This PR adds a basic test for the thread-safety of FINUFFT in julia. According to #63 , this test fails on MacOS but not on Windows or Linux.  

Update: The underlying issue has been fixed by https://github.com/JuliaPackaging/Yggdrasil/pull/13252. This PR adds the previously problematic scenario of calling both FINUFFT and FFTW in a multi-threaded scenario to the package tests.