### PR TITLE
Temporarily use safe FFTW planning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "3.2.0"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 cufinufft_jll = "d94e68af-94a2-5465-a03a-ccb69bb7181e"
 finufft_jll = "c41cd5a2-72a3-5203-9076-a500b088fc82"
+FFTW_jll = "f5851436-0d7a-5f13-b9de-f02708fd171a"
 
 [compat]
 Requires = "1.3"

--- a/src/FINUFFT.jl
+++ b/src/FINUFFT.jl
@@ -50,8 +50,8 @@ include("simple.jl")
 function __init__()
 
     # quick and dirty: make fftw thread safe
-    ccall((:fftw_make_planner_thread_safe, libfftw3), Cvoid, (Cvoid,), Ref(nothing))
-    ccall((:fftwf_make_planner_thread_safe, libfftw3f), Cvoid, (Cvoid,), Ref(nothing))
+    ccall((:fftw_make_planner_thread_safe, libfftw3), Cvoid, ())
+    ccall((:fftwf_make_planner_thread_safe, libfftw3f), Cvoid, ())
 
     @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
         using .CUDA

--- a/src/FINUFFT.jl
+++ b/src/FINUFFT.jl
@@ -27,6 +27,7 @@ export finufftReal
 # By default we depend on our precompiled generic binary package...
 using finufft_jll
 const libfinufft = finufft_jll.libfinufft
+# part of the thread-safety workaround
 using FFTW_jll
 const libfftw3 = FFTW_jll.libfftw3
 const libfftw3f = FFTW_jll.libfftw3f
@@ -50,6 +51,7 @@ include("simple.jl")
 function __init__()
 
     # quick and dirty: make fftw thread safe
+    # get rid of this workaround as soon as https://github.com/flatironinstitute/finufft/pull/548 has been merged and deployed to finufft_jll
     ccall((:fftw_make_planner_thread_safe, libfftw3), Cvoid, ())
     ccall((:fftwf_make_planner_thread_safe, libfftw3f), Cvoid, ())
 

--- a/src/FINUFFT.jl
+++ b/src/FINUFFT.jl
@@ -27,6 +27,9 @@ export finufftReal
 # By default we depend on our precompiled generic binary package...
 using finufft_jll
 const libfinufft = finufft_jll.libfinufft
+using FFTW_jll
+const libfftw3 = FFTW_jll.libfftw3
+const libfftw3f = FFTW_jll.libfftw3f
 #
 # If instead you want to use your locally-compiled FINUFFT library for more
 # performance, comment out the above two code lines, uncomment the upcoming
@@ -45,6 +48,11 @@ include("simple.jl")
 
 # Only load cuFINUFFT interface if CUDA is present (via `using CUDA`) and functional
 function __init__()
+
+    # quick and dirty: make fftw thread safe
+    ccall((:fftw_make_planner_thread_safe, libfftw3), Cvoid, (Cvoid,), Ref(nothing))
+    ccall((:fftwf_make_planner_thread_safe, libfftw3f), Cvoid, (Cvoid,), Ref(nothing))
+
     @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
         using .CUDA
         include("cufinufft.jl")


### PR DESCRIPTION
This PR explicitly loads `FFTW_jll` to enforce thread-safe planning for FFTW hence provisorily fixing #62 . As soon as https://github.com/flatironinstitute/finufft/pull/548 is merged, we can update `finufft_jll` and employ the changes over at https://github.com/jkrimmer/FINUFFT.jl/tree/user_fftw_lock instead. 