### PR TITLE
Add support for GPU type 3 transform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FINUFFT"
 uuid = "d8beea63-0952-562e-9c6a-8e8ef7364055"
 author = "Ludvig af Klinteberg <ludvig.af.klinteberg@mdu.se>"
-version = "3.3.1"
+version = "3.4.0"
 
 [deps]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -11,8 +11,8 @@ FFTW_jll = "f5851436-0d7a-5f13-b9de-f02708fd171a"
 
 [compat]
 Requires = "1.3"
-cufinufft_jll = "2.3.1"
-finufft_jll = "2.3.1"
+cufinufft_jll = "2.4.0"
+finufft_jll = "2.4.0"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a full-featured Julia interface to [FINUFFT](https://github.com/flatiron
 
 ## Installation
 
-FINUFFT.jl requires Julia v1.6 or later, and has been tested up to v1.10. From the Pkg REPL mode (hit `]` in REPL to enter), run
+FINUFFT.jl requires Julia v1.6 or later, and has been tested up to v1.11. From the Pkg REPL mode (hit `]` in REPL to enter), run
 
 ```julia
 add FINUFFT
@@ -105,7 +105,7 @@ see [examples/time2d1.jl](examples/time2d1.jl)
 
 Finally, the more involved codes [test/test_nufft.jl](test/test_nufft.jl) 
 and [test/test_cuda.jl](test/test_cuda.jl)
-tests `dtype=Float64` and `dtype=Float32` precisions for all supported transform types, and can be used as references.
+test `dtype=Float64` and `dtype=Float32` precisions for all supported transform types, and can be used as references.
 The outputs are tested there for mathematical correctness.
 In the 1D type 1 it also tests a vectorized simple, a guru call and
 a vectorized guru call.

--- a/src/cufinufft.jl
+++ b/src/cufinufft.jl
@@ -122,7 +122,6 @@ function _cufinufft_makeplan(::Type{dtype},
 
     n_modes = ones(Int64,3)
     if type==3
-        throw("Type 3 not implemented yet")
         @assert ndims(n_modes_or_dim) == 0
         dim = n_modes_or_dim
     else
@@ -130,7 +129,7 @@ function _cufinufft_makeplan(::Type{dtype},
         dim = length(n_modes_or_dim)
         n_modes[1:dim] .= n_modes_or_dim
     end
-    
+
     if dtype==Float64
         tol = Float64(eps)
         ret = ccall( (:cufinufft_makeplan, libcufinufft),
@@ -412,6 +411,30 @@ function cufinufft_exec!(plan::cufinufft_plan{T},
                           CuRef{ComplexF32},
                           CuRef{ComplexF32}),
                          plan.plan_ptr,output,input
+                         )
+        end
+    elseif type==3
+        nk = plan.nk
+        if ntrans==1
+            @assert size(output)==(nk,ntrans) || size(output)==(nk,)
+        else
+            @assert size(output)==(nk,ntrans)
+        end
+        if T==Float64
+            ret = ccall( (:cufinufft_execute, libcufinufft),
+                         Cint,
+                         (cufinufft_plan_c,
+                          CuRef{ComplexF64},
+                          CuRef{ComplexF64}),
+                         plan.plan_ptr,input,output
+                         )
+        else
+            ret = ccall( (:cufinufftf_execute, libcufinufft),
+                         Cint,
+                         (cufinufft_plan_c,
+                          CuRef{ComplexF32},
+                          CuRef{ComplexF32}),
+                         plan.plan_ptr,input,output
                          )
         end
     else

--- a/src/cufinufft_simple.jl
+++ b/src/cufinufft_simple.jl
@@ -60,6 +60,35 @@ function nufft1d2!(xj      :: CuArray{T},
     cufinufft_destroy!(plan)
 end
 
+"""
+    nufft1d3!(xj      :: CuArray{Float64} or CuArray{Float32}, 
+              cj      :: CuArray{ComplexF64} or CuArray{ComplexF32}, 
+              iflag   :: Integer, 
+              eps     :: Real,
+              sk      :: CuArray{Float64} or CuArray{Float32},
+              fk      :: CuArray{ComplexF64} or CuArray{ComplexF32};
+              kwargs...
+             )
+
+CUDA version.
+"""
+function nufft1d3!(xj      :: CuArray{T},
+                   cj      :: CuArray{Complex{T}},
+                   iflag   :: Integer, 
+                   eps     :: Real,
+                   sk      :: CuArray{T},
+                   fk      :: CuArray{Complex{T}};
+                   kwargs...) where T <: finufftReal
+    (nj, nk) = valid_setpts(3,1,xj,T[],T[],sk)
+    ntrans = valid_ntr(xj,cj)
+
+    checkkwdtype(T; kwargs...)
+    plan = _cufinufft_makeplan(T,3,1,iflag,ntrans,eps;kwargs...)
+    cufinufft_setpts!(plan,xj,CuVector{T}(),CuVector{T}(),sk)
+    cufinufft_exec!(plan,cj,fk)
+    cufinufft_destroy!(plan)
+end
+
 ## 2D
 
 """
@@ -122,6 +151,40 @@ function nufft2d2!(xj      :: CuArray{T},
     cufinufft_exec!(plan,fk,cj)
     cufinufft_destroy!(plan)
 end
+
+"""
+    nufft2d3!(xj      :: CuArray{Float64} or CuArray{Float32}, 
+              yj      :: CuArray{Float64} or CuArray{Float32},
+              cj      :: CuArray{ComplexF64} or CuArray{ComplexF32}, 
+              iflag   :: Integer, 
+              eps     :: Real,
+              sk      :: CuArray{Float64} or CuArray{Float32},
+              tk      :: CuArray{Float64} or CuArray{Float32},
+              fk      :: CuArray{ComplexF64} or CuArray{ComplexF32};
+              kwargs...
+             )
+
+CUDA version.
+"""
+function nufft2d3!(xj      :: CuArray{T}, 
+                   yj      :: CuArray{T},
+                   cj      :: CuArray{Complex{T}}, 
+                   iflag   :: Integer, 
+                   eps     :: Real,
+                   sk      :: CuArray{T},
+                   tk      :: CuArray{T},
+                   fk      :: CuArray{Complex{T}};
+                   kwargs...) where T <: finufftReal
+    (nj, nk) = valid_setpts(3,2,xj,yj,T[],sk,tk)
+    ntrans = valid_ntr(xj,cj)
+
+    checkkwdtype(T; kwargs...)
+    plan = _cufinufft_makeplan(T,3,2,iflag,ntrans,eps;kwargs...)
+    cufinufft_setpts!(plan,xj,yj,CuVector{T}(),sk,tk)
+    cufinufft_exec!(plan,cj,fk)
+    cufinufft_destroy!(plan)
+end
+
 
 ## 3D
 
@@ -188,3 +251,41 @@ function nufft3d2!(xj      :: CuArray{T},
     cufinufft_exec!(plan,fk,cj)
     cufinufft_destroy!(plan)
 end
+
+"""
+    nufft3d3!(xj      :: CuArray{Float64} or CuArray{Float32}, 
+              yj      :: CuArray{Float64} or CuArray{Float32},
+              zj      :: CuArray{Float64} or CuArray{Float32},
+              cj      :: CuArray{ComplexF64} or CuArray{ComplexF32}, 
+              iflag   :: Integer, 
+              eps     :: Real,
+              sk      :: CuArray{Float64} or CuArray{Float32},
+              tk      :: CuArray{Float64} or CuArray{Float32},
+              uk      :: CuArray{Float64} or CuArray{Float32},
+              fk      :: CuArray{ComplexF64} or CuArray{ComplexF32};
+              kwargs...
+             )
+
+CUDA version.
+"""
+function nufft3d3!(xj      :: CuArray{T},
+                   yj      :: CuArray{T},
+                   zj      :: CuArray{T},
+                   cj      :: CuArray{Complex{T}},
+                   iflag   :: Integer,
+                   eps     :: Real,
+                   sk      :: CuArray{T},
+                   tk      :: CuArray{T},
+                   uk      :: CuArray{T},
+                   fk      :: CuArray{Complex{T}};
+                   kwargs...) where T <: finufftReal
+    (nj, nk) = valid_setpts(3,3,xj,yj,zj,sk,tk,uk)
+    ntrans = valid_ntr(xj,cj)
+
+    checkkwdtype(T; kwargs...)
+    plan = _cufinufft_makeplan(T,3,3,iflag,ntrans,eps;kwargs...)
+    cufinufft_setpts!(plan,xj,yj,zj,sk,tk,uk)
+    cufinufft_exec!(plan,cj,fk)
+    cufinufft_destroy!(plan)
+end
+

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -2,28 +2,29 @@
 
 # Following should match error codes in https://github.com/flatironinstitute/finufft/blob/master/include/finufft_errors.h
 
-const WARN_EPS_TOO_SMALL            = 1
-const ERR_MAXNALLOC                 = 2
-const ERR_SPREAD_BOX_SMALL          = 3
-const ERR_SPREAD_PTS_OUT_RANGE      = 4 # DEPRECATED
-const ERR_SPREAD_ALLOC              = 5
-const ERR_SPREAD_DIR                = 6
-const ERR_UPSAMPFAC_TOO_SMALL       = 7
-const ERR_HORNER_WRONG_BETA         = 8
-const ERR_NTRANS_NOTVALID           = 9
-const ERR_TYPE_NOTVALID             = 10
-const ERR_ALLOC                     = 11
-const ERR_DIM_NOTVALID              = 12
-const ERR_SPREAD_THREAD_NOTVALID    = 13
-const ERR_NDATA_NOTVALID            = 14
-const ERR_CUDA_FAILURE              = 15
-const ERR_PLAN_NOTVALID             = 16
-const ERR_METHOD_NOTVALID           = 17
-const ERR_BINSIZE_NOTVALID          = 18
-const ERR_INSUFFICIENT_SHMEM        = 19
-const ERR_NUM_NU_PTS_INVALID        = 20
-const ERR_LOCK_FUNS_INVALID         = 22
-const ERR_SPREADONLY_UPSAMP_INVALID = 23
+const WARN_EPS_TOO_SMALL         = 1
+const ERR_MAXNALLOC              = 2
+const ERR_SPREAD_BOX_SMALL       = 3
+const ERR_SPREAD_PTS_OUT_RANGE   = 4 # DEPRECATED
+const ERR_SPREAD_ALLOC           = 5
+const ERR_SPREAD_DIR             = 6
+const ERR_UPSAMPFAC_TOO_SMALL    = 7
+const ERR_HORNER_WRONG_BETA      = 8
+const ERR_NTRANS_NOTVALID        = 9
+const ERR_TYPE_NOTVALID          = 10
+const ERR_ALLOC                  = 11
+const ERR_DIM_NOTVALID           = 12
+const ERR_SPREAD_THREAD_NOTVALID = 13
+const ERR_NDATA_NOTVALID         = 14
+const ERR_CUDA_FAILURE           = 15
+const ERR_PLAN_NOTVALID          = 16
+const ERR_METHOD_NOTVALID        = 17
+const ERR_BINSIZE_NOTVALID       = 18
+const ERR_INSUFFICIENT_SHMEM     = 19
+const ERR_NUM_NU_PTS_INVALID     = 20
+const ERR_INVALID_ARGUMENT       = 21
+const ERR_LOCK_FUNS_INVALID      = 22
+const ERR_NTHREADS_NOTVALID      = 23
 
 struct FINUFFTError <: Exception
     errno::Cint
@@ -81,8 +82,10 @@ function check_ret(ret)
         msg = "GPU shmem too small for subprob/blockgather parameters"
     elseif ret==ERR_NUM_NU_PTS_INVALID
         msg = "invalid number of nonuniform points: nj or nk negative, or too big (see defs.h)"
-    elseif ret==ERR_SPREADONLY_UPSAMP_INVALID
-        msg = "invalid upsampfac set while using gpu_spreadinterponly mode"
+    elseif ret==FINUFFT_ERR_INVALID_ARGUMENT
+        msg == "invalid argument"
+    elseif ret==FINUFFT_ERR_NTHREADS_NOTVALID
+        msg = "nthreads not valid"
     else
         msg = "error of type unknown to Julia interface! Check FINUFFT documentation"
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -130,6 +130,7 @@ const nufft_c_opts = nufft_opts        # for backward compatibility - remove?
         gpu_stream           :: Ptr{Cvoid}
         modeord              :: Cint # (type 1,2 only): 0 CMCL-style increasing mode order
                                      #                  1 FFT-style mode order
+        debug                :: Cint # 0: no debug, 1: debug
     end
 
 Options struct passed to cuFINUFFT, see C documentation.
@@ -162,6 +163,8 @@ mutable struct cufinufft_opts
     gpu_stream           :: Ptr{Cvoid}
 
     modeord              :: Cint # (type 1,2 only): 0 CMCL-style increasing mode order
-                                 #                  1 FFT-style mode order
+    #                  1 FFT-style mode order
+
+    debug                :: Cint # 0: no debug, 1: debug
     cufinufft_opts() = new()
 end

--- a/test/test_cuda.jl
+++ b/test/test_cuda.jl
@@ -50,6 +50,9 @@ function test_cuda(tol::Real, dtype::DataType)
     y_d = CuArray(y)
     z_d = CuArray(z)
     c_d = CuArray(c)
+    s_d = CuArray(s)
+    t_d = CuArray(t)
+    u_d = CuArray(u)
     F1D_d = CuArray(F1D)
     F2D_d = CuArray(F2D)
     F3D_d = CuArray(F3D)
@@ -128,6 +131,21 @@ function test_cuda(tol::Real, dtype::DataType)
                 relerr_1d2_guru = norm(vec(out2)-vec(ref), Inf) / norm(vec(ref), Inf)
                 @test relerr_1d2_guru < errfac*tol
             end
+
+            # 1D3
+            @testset "1D3" begin
+                out_d = CUDA.zeros(Complex{T},nk)
+                ref = zeros(Complex{T},nk)
+                for k=1:nk
+                    for j=1:nj
+                        ref[k] += c[j] * exp(1im*s[k]*x[j])
+                    end
+                end
+                nufft1d3!(x_d,c_d,1,tol,s_d,out_d, debug=1, gpu_method=1) # FIXME
+                relerr_1d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
+                @test relerr_1d3 < errfac*tol
+            end
+
         end
 
         ## 2D
@@ -176,6 +194,20 @@ function test_cuda(tol::Real, dtype::DataType)
                 cufinufft_destroy!(plan)
                 relerr_2d2_guru = norm(vec(out2)-vec(ref), Inf) / norm(vec(ref), Inf)
                 @test relerr_2d2_guru < errfac*tol
+            end
+
+            @testset "2D3" begin
+                # 2D3
+                out_d = CUDA.zeros(Complex{T},nk)
+                ref = zeros(Complex{T},nk)
+                for k=1:nk
+                    for j=1:nj
+                        ref[k] += c[j] * exp(1im*(s[k]*x[j]+t[k]*y[j]))
+                    end
+                end
+                nufft2d3!(x_d,y_d,c_d,1,tol,s_d,t_d,out_d, debug=1, gpu_method=1) # FIXME
+                relerr_2d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
+                @test relerr_2d3 < errfac*tol
             end
         end
 
@@ -231,6 +263,19 @@ function test_cuda(tol::Real, dtype::DataType)
                 @test relerr_3d2_guru < errfac*tol
             end
 
+            @testset "3D3" begin
+                # 3D3
+                out_d = CUDA.zeros(Complex{T},nk)
+                ref = zeros(Complex{T},nk)
+                for k=1:nk
+                    for j=1:nj
+                        ref[k] += c[j] * exp(1im*(s[k]*x[j]+t[k]*y[j]+u[k]*z[j]))
+                    end
+                end
+                nufft3d3!(x_d,y_d,z_d,c_d,1,tol,s_d,t_d,u_d,out_d, debug=1, gpu_method=1) # FIXME
+                relerr_3d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
+                @test relerr_3d3 < errfac*tol
+            end
         end
     end
 end

--- a/test/test_cuda.jl
+++ b/test/test_cuda.jl
@@ -141,7 +141,7 @@ function test_cuda(tol::Real, dtype::DataType)
                         ref[k] += c[j] * exp(1im*s[k]*x[j])
                     end
                 end
-                nufft1d3!(x_d,c_d,1,tol,s_d,out_d, debug=1, gpu_method=1) # FIXME
+                nufft1d3!(x_d,c_d,1,tol,s_d,out_d)
                 relerr_1d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
                 @test relerr_1d3 < errfac*tol
             end
@@ -205,7 +205,7 @@ function test_cuda(tol::Real, dtype::DataType)
                         ref[k] += c[j] * exp(1im*(s[k]*x[j]+t[k]*y[j]))
                     end
                 end
-                nufft2d3!(x_d,y_d,c_d,1,tol,s_d,t_d,out_d, debug=1, gpu_method=1) # FIXME
+                nufft2d3!(x_d,y_d,c_d,1,tol,s_d,t_d,out_d)
                 relerr_2d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
                 @test relerr_2d3 < errfac*tol
             end
@@ -272,7 +272,7 @@ function test_cuda(tol::Real, dtype::DataType)
                         ref[k] += c[j] * exp(1im*(s[k]*x[j]+t[k]*y[j]+u[k]*z[j]))
                     end
                 end
-                nufft3d3!(x_d,y_d,z_d,c_d,1,tol,s_d,t_d,u_d,out_d, debug=1, gpu_method=1) # FIXME
+                nufft3d3!(x_d,y_d,z_d,c_d,1,tol,s_d,t_d,u_d,out_d)
                 relerr_3d3 = norm(vec(Array(out_d))-vec(ref), Inf) / norm(vec(ref), Inf)
                 @test relerr_3d3 < errfac*tol
             end

--- a/test/test_nufft.jl
+++ b/test/test_nufft.jl
@@ -165,7 +165,7 @@ function test_nufft(tol::Real, dtype::DataType)
                 @test reldiff < errdifffac*tol
             end
 
-            @testset "3D3" begin
+            @testset "2D3" begin
                 # 2D3
                 out = zeros(Complex{T},nk)
                 ref = zeros(Complex{T},nk)


### PR DESCRIPTION
Resolves #68 

 * Tests are tentative pending fix of gpu_method=0 bug
 * Fix some typos along the way

- [x] Remove FIXMEs with `debug=1, gpu_method=1` once cuFINUFFT bug is fixed:
https://github.com/flatironinstitute/finufft/pull/576
- [ ] Do not merge until FINUFFT with GPU type 3 is released (v2.4.0?)
