### PR TITLE
fix: towards avoiding NodeJS deprecations in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
           - os: macOS-latest
             arch: aarch64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -41,8 +41,8 @@ jobs:
         env:
           JULIA_NUM_THREADS: ${{ env.NUM_THREADS || 2 }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false 

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -10,7 +10,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:


### PR DESCRIPTION
This PR updates actions/checkout (v2 → v6) and codecov/codecain-action (v4 → v6) in the CI and Documenter workflows. These updates address part of the NodeJS deprecation warnings currently observed in CI logs.

Note: The warnings persist because the latest release of julia-actions/setup-julia does not yet include the fix from [PR #374](https://github.com/julia-actions/setup-julia/pull/374). Once that update is released, these warnings should be fully resolved.