### PR TITLE
Update to finufft v2.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ CUFINUFFTExt = "CUDA"
 
 [compat]
 CUDA = "5"
-cufinufft_jll = "~2.5"
-finufft_jll = "~2.5"
+cufinufft_jll = "=2.5.1"
+finufft_jll = "=2.5.1"
 julia = "1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FINUFFT"
 uuid = "d8beea63-0952-562e-9c6a-8e8ef7364055"
 author = "Ludvig af Klinteberg <ludvig.af.klinteberg@mdu.se>"
-version = "3.5.1"
+version = "3.5.2"
 
 [deps]
 cufinufft_jll = "d94e68af-94a2-5465-a03a-ccb69bb7181e"
@@ -17,8 +17,8 @@ CUFINUFFTExt = "CUDA"
 
 [compat]
 CUDA = "5"
-cufinufft_jll = "=2.5.0"
-finufft_jll = "=2.5.0"
+cufinufft_jll = "~2.5"
+finufft_jll = "~2.5"
 julia = "1.9"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/ludvigak/FINUFFT.jl/branch/master/graph/badge.svg?token=Tkx7kma18J)](https://codecov.io/gh/ludvigak/FINUFFT.jl)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://ludvigak.github.io/FINUFFT.jl/latest/)
 
-This is a full-featured Julia interface to [FINUFFT](https://github.com/flatironinstitute/finufft), which is a lightweight and fast parallel nonuniform fast Fourier transform (NUFFT) library released by the Flatiron Institute, and its GPU version cuFINUFFT. This interface stands at v3.x, and it uses FINUFFT version 2.5.0 (note that the interface version number is distinct from the version of the wrapped binary FINUFFT library).
+This is a full-featured Julia interface to [FINUFFT](https://github.com/flatironinstitute/finufft), which is a lightweight and fast parallel nonuniform fast Fourier transform (NUFFT) library released by the Flatiron Institute, and its GPU version cuFINUFFT. This interface stands at v3.x, and it uses FINUFFT version 2.x (note that the interface version number is distinct from the version of the wrapped binary FINUFFT library).
 
 ## Installation
 


### PR DESCRIPTION
To support finufft v2.5.1, this PR relaxes the version specifications for `finufft_jll` and `cufinufft_jll`. Accordingly, I have incremented the package version number to account for the accompanying library version update. Please let me know what you think.