### PR TITLE
Allow CUDA.jl v6 (compat "5, 6")

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ FFTWLock = "FFTW"
 CUFINUFFTExt = "CUDA"
 
 [compat]
-CUDA = "5"
+CUDA = "5, 6"
 cufinufft_jll = "=2.5.1"
 finufft_jll = "=2.5.1"
 julia = "1.9"


### PR DESCRIPTION
As far as I can tell, there's no reason to disallow CUDA 6.



Thus, this PR widens the CUDA compat bound from `"5"` to `"5, 6"`. This is the only change
needed to use FINUFFT.jl with CUDA.jl v6 — no source changes.

From what I can tell:
- CUDA.jl v6.0 is a subpackage split ("ideally no breaking changes"); the only
  deprecations are submodule renames (`CUBLAS` → `cuBLAS.jl`, …), and I don't believe this package references them in any way
- Every CUDA symbol the extension touches — `CuArray`, `CuVector`, `CuRef`,
  `CUDA.functional`, `CUDA.zeros`, `vec` — is still exported from `CUDACore`
  and re-exported by `CUDA`. The `CuRef` → device-pointer `ccall` path
  (`refpointer.jl`) is unchanged from v5.
- `cufinufft_jll = "=2.5.1"` already provides CUDA 11.8–13.2 binaries, so the
  exact pin is unchanged I believe as well. I checked at 
  [https://github.com/JuliaBinaryWrappers/cufinufft_jll.jl](https://github.com/JuliaBinaryWrappers/cufinufft_jll.jl) which points to [https://github.com/JuliaPackaging/Yggdrasil/blob/c29e25f2b54de6d8f64eaa49885770ecab08ea82/C/cufinufft/build_tarballs.jl#L82](https://github.com/JuliaPackaging/Yggdrasil/blob/c29e25f2b54de6d8f64eaa49885770ecab08ea82/C/cufinufft/build_tarballs.jl#L82) , and everything works fine on my machine (with A100)

I tested on a local machine, with :
 - Julia 1.12.6, CUDA.jl 6.2.1, CUDA runtime 13.3 (driver 580.82.07):

and still found:
| suite | result |
|---|---|
| CPU (`FINUFFT`) | 68/68 pass |
| GPU (`cuFINUFFT`) | 40/40 pass |

(note i only asked for 1 thread)

Let me know if there are any issues.